### PR TITLE
Reference Types correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/tmpvar/vec2.js.git"
   },
   "main": "vec2.js",
-  "typings": "types",
+  "typings": "types/global.d.ts",
   "scripts": {
     "test": "mocha test/test.js",
     "cover": "istanbul cover _mocha -- test/test.js -R spec",


### PR DESCRIPTION
VSCode didn't pick up on `Vec2` types for me and shows that it can't find them. It looks like the `types` field in `package.json` needs to reference an actual file. In Vec2s case `types/global.d.ts`.

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

Please let me know if there's something I'm missing, I'm pretty new to Typescript.